### PR TITLE
fix(warning): malformed hexcode 'fg'

### DIFF
--- a/schemes/gruvbox
+++ b/schemes/gruvbox
@@ -32,7 +32,7 @@
 "markup.heading.3" = { fg = "yellow", modifiers = ["bold"] }
 "markup.heading.4" = { fg = "green", modifiers = ["bold"] }
 "markup.heading.5" = { fg = "blue", modifiers = ["bold"] }
-"markup.heading.6" = { fg = "fg", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "fg0", modifiers = ["bold"] }
 "markup.list" = "red"
 "markup.bold" = { modifiers = ["bold"] }
 "markup.italic" = { modifiers = ["italic"] }


### PR DESCRIPTION
Gruvbox themes have a palette containing colors for `fg0` and `fg1`, but the scheme for gruvbox references a non-existent `fg` for `markup.heading.h6`. This occasionally sends a warning to the helix log file and seemingly falls back to a regular common foreground color. This PR fixes that scheme for gruvbox referencing `fg0` instead.