### PR TITLE
Add curled and dotted underline for diagnostics

### DIFF
--- a/schemes/edge
+++ b/schemes/edge
@@ -79,6 +79,10 @@
 "warning" = "yellow"
 "error" = "red"
 "diagnostic" = { underline = { style = "line" } }
+"diagnostic.hint" = { underline = { color = "blue", style = "dotted" } }
+"diagnostic.info" = { underline = { color = "green", style = "dotted" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
 
 [palette]
 

--- a/schemes/edge
+++ b/schemes/edge
@@ -78,7 +78,7 @@
 "info" = "green"
 "warning" = "yellow"
 "error" = "red"
-"diagnostic" = { modifiers = ["underlined"] }
+"diagnostic" = { underline = { style = "line" } }
 
 [palette]
 

--- a/schemes/everforest
+++ b/schemes/everforest
@@ -79,6 +79,10 @@
 "warning" = "yellow"
 "error" = "red"
 "diagnostic" = { underline = { style = "curl" } }
+"diagnostic.hint" = { underline = { color = "blue", style = "dotted" } }
+"diagnostic.info" = { underline = { color = "aqua", style = "dotted" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
 
 [palette]
 

--- a/schemes/everforest
+++ b/schemes/everforest
@@ -78,7 +78,7 @@
 "info" = "aqua"
 "warning" = "yellow"
 "error" = "red"
-"diagnostic" = { modifiers = ["underlined"] }
+"diagnostic" = { underline = { style = "curl" } }
 
 [palette]
 

--- a/schemes/gruvbox
+++ b/schemes/gruvbox
@@ -79,6 +79,10 @@
 "warning" = "yellow"
 "error" = "red"
 "diagnostic" = { underline = { style = "curl" } }
+"diagnostic.hint" = { underline = { color = "blue", style = "dotted" } }
+"diagnostic.info" = { underline = { color = "aqua", style = "dotted" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
 
 [palette]
 

--- a/schemes/gruvbox
+++ b/schemes/gruvbox
@@ -78,7 +78,7 @@
 "info" = "aqua"
 "warning" = "yellow"
 "error" = "red"
-"diagnostic" = { modifiers = ["underlined"] }
+"diagnostic" = { underline = { style = "curl" } }
 
 [palette]
 

--- a/schemes/kanabox
+++ b/schemes/kanabox
@@ -82,7 +82,7 @@
 "info" = "crystalBlue"
 "warning" = "carpYellow"
 "error" = "peachRed"
-"diagnostic" = { modifiers = ["underlined"] }
+"diagnostic" = { underline = { style = "line" } }
 
 [palette]
 

--- a/schemes/kanabox
+++ b/schemes/kanabox
@@ -83,6 +83,10 @@
 "warning" = "carpYellow"
 "error" = "peachRed"
 "diagnostic" = { underline = { style = "line" } }
+"diagnositc.hint" = { underline = { color = "springBlue", style = "dotted" } }
+"diagnositc.info" = { underline = { color = "crystalBlue", style = "dotted" } }
+"diagnositc.warning" = { underline = { color = "carpYellow", style = "curl" } }
+"diagnositc.error" = { underline = { color = "peachRed", style = "curl" } }
 
 [palette]
 

--- a/schemes/sonokai
+++ b/schemes/sonokai
@@ -78,7 +78,7 @@
 "info" = "green"
 "warning" = "yellow"
 "error" = "red"
-"diagnostic" = { modifiers = ["underlined"] }
+"diagnostic" = { underlined = { style = "line" } }
 
 [palette]
 

--- a/schemes/sonokai
+++ b/schemes/sonokai
@@ -79,6 +79,10 @@
 "warning" = "yellow"
 "error" = "red"
 "diagnostic" = { underlined = { style = "line" } }
+"diagnostic.hint" = { underline = { color = "blue", style = "dotted" } }
+"diagnostic.info" = { underline = { color = "green", style = "dotted" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
 
 [palette]
 


### PR DESCRIPTION
I'm wondering if support for underline styles ([helix#3015](https://github.com/helix-editor/helix/pull/3015), superseded by [helix#4064](https://github.com/helix-editor/helix/pull/4061)) is planned. This would bring the themes in this repo on par with the default themes in terms of diagnostic support.

There are currently 4 underline styles: 
- `curl`
- `dashed`
- `dotted` (docs mention `dot` but that is not correct on [master](https://github.com/helix-editor/helix/blob/ac0fe29867012ba0840ee7c8893b41d976d5ab38/helix-view/src/graphics.rs#L335))
- `double_underline`

These should ideally feel familiar, so the color should match the gutter icon's color, the style should match what other popular editors do.


### Other Editors
Diagnostic differences:
|helix/lsp|intelij-based|vscode|
|---|---|---|
error|error|error|
warning|warning|warning|
info|hint|info|
hint|suggestion|info (different styling)|

#### IntelliJ-based IDEs
|severity|underline type|color|styling|
|---|---|---|---|
|error|`undercurled`|vibrant red| -|
|warning|`undercurled`|soft red| - |
|info|`underdotted`|vibrant cyan|short span, nothing we have control over|
|hint|`undercurled`|soft yellow| - |

#### Visual Studio Code
|severity|underline type|color|styling|
|---|---|---|---|
|error|`undercurled`|vibrant red| - |
|warning|`undercurled`|vibrant yellow| - |
|info|`underdashed`|vibrant cyan|short span, nothing we have control over|
|hint|`underdashed`|soft yellow| - |

Most themes for these editors don't interfere with the default styling of the diagnostics. The changes are simple
```diff
+ "diagnostic.hint" = { underline = { color = <hint>, style = "dotted" } }
+ "diagnostic.info" = { underline = { color = <info>, style = "dotted" } }
+ "diagnostic.warning" = { underline = { color = <warning>, style = "curl" } }
+ "diagnostic.error" = { underline = { color = <error>, style = "curl" } }
```

As well as removing the deprecated option for the fallback style and changing it to curl (same as the default theme):
```diff
- "diagnostic" = { modifiers = ["underlined"] }
+ "diagnostic" = { underline = { style = "line" } }
```

I've tried this with `gruvbox_original_dark_hard` only, but I figure this Is simple enough that it should work for all of them.
It's up to you if prefer curl for all of them or dashed over dotted, I thought the distinction from color only is a bit hard to see, and the dashed underline looked kind of weird to me.