### PR TITLE
Add home-manager support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /build
+*result

--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ To "install" a theme simply copy it into that directory (you may have to create 
 
 If you are unsure where the config path is located on your machine, run `hx --health` and look for `Config file: ...` at the top. You can read more about themes in the Helix docs [here](https://docs.helix-editor.com/themes.html).
 
+### Home Manager Module
+
+Nix users can either use the flake overlay to add the package to their package set, then use home-manager to
+symlink the directory to their helix theme directory as described in [installation](#installation), or use the
+home-manager module from the flake which automatically sets [`programs.helix.themes`](https://nix-community.github.io/home-manager/options.xhtml#opt-programs.helix.themes) if helix is enabled.
+
 ### Building manually
 
 Themes are split into a color scheme or "mapping" ("constants are purple") and one or more palettes ("purple is `#b39df3`").

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,2 @@
+{ pkgs ? import <nixpkgs> { } }:
+pkgs.callPackage (builtins.getFlake (toString ./.)).outputs.package { }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,75 @@
+{
+  description = "A few themes for the helix editor";
+
+  outputs = { self }:
+    {
+      package = { stdenvNoCC, lib }:
+        stdenvNoCC.mkDerivation {
+          pname = "helix-themes";
+          version = "0.1.0";
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./build.sh
+              ./schemes
+              ./palettes
+              ./LICENSE
+            ];
+          };
+          phases = [
+            "unpackPhase"
+            "preBuild"
+            "buildPhase"
+            "installPhase"
+          ];
+          preBuild = ''
+            chmod +x ./build.sh
+            patchShebangs ./build.sh
+          '';
+          buildPhase = ''
+            bash -c ./build.sh
+          '';
+          installPhase = ''
+            mkdir -p $out
+            cp -r ./build/*.toml $out
+            cp ./LICENSE $out
+          '';
+          meta = {
+            homepage = "https://github.com/CptPotato/helix-themes";
+            description = "A few themes for the helix editor";
+            license = lib.licenses.mit;
+          };
+        };
+
+      overlay = final: prev: {
+        helix-themes = prev.callPackage self.package { };
+      };
+
+      homeManagerModule = { config, lib, pkgs, ... }:
+        let
+          cfg = config.programs.helix;
+        in
+        {
+          options.programs.helix.themes-package = lib.mkOption {
+            type = lib.types.package;
+            default = pkgs.callPackage self.package { };
+            description = "Package containing TOML theme files for the helix editor.";
+          };
+
+          config = lib.mkIf (cfg.enable or false) {
+            programs.helix.themes =
+              let
+                toml2nix = name: _type: builtins.fromTOML
+                  (builtins.readFile "${cfg.themes-package}/${name}");
+                tomlFiles = lib.filterAttrs
+                  (n: _: lib.hasSuffix ".toml" n)
+                  (builtins.readDir "${cfg.themes-package}");
+              in
+              lib.mapAttrs' (name: type: lib.nameValuePair
+                (lib.removeSuffix ".toml" name)
+                (toml2nix name type)
+              ) tomlFiles;
+          };
+        };
+    };
+}


### PR DESCRIPTION
Hi there, I've been using your themes with nix for quite some time now and I previously converted them to nix expression to use with home-manager but now that I've had a second I decided to go ahead and make this way easier. The result is that by just including the `homeManagerModule` from the flake it loads all of the helix themes automatically if helix is enabled with home-manager. I'm currently using this on my systems, and figured I'd open a PR to see if you'd like to include the flake in the repo for others to use. The default.nix entry point is also available for those that just want the package itself.

You can build it with `nix-build`, or include the home-manager module like so:

```nix
# flake.nix
{
  inputs = {
    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
    home-manager = {
      url = "github:nix-community/home-manager";
      inputs.nixpkgs.follows = "nixpkgs";
    };
    helix-themes.url = "github:eureka-cpu/helix-themes?ref=eureka-cpu/0";
  };
  outputs =
    { self
    , nixpkgs
    , home-manager
    , helix-themes
    }:
    {
      nixosConfigurations = {
        nixos = nixpkgs.lib.nixosSystem {
          modules = [
            ./configuration.nix # your machine config
            home-manager.nixosModules.home-manager
            {
              home-manager = {
                useUserPackages = true;
                useGlobalPkgs = true;
                sharedModules = [
                  helix-themes.homeManagerModule
                ];
                users.${user} = ./home.nix; # your user
              };
            }
          ];
        };
      };
    };
}
```